### PR TITLE
Support smooth world map point movement

### DIFF
--- a/src/main/java/com/gimp/GimPluginConfig.java
+++ b/src/main/java/com/gimp/GimPluginConfig.java
@@ -52,4 +52,14 @@ public interface GimPluginConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "showSelf",
+			name = "Show Self",
+			description = "Show yourself on the map"
+	)
+	default boolean showSelf()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/gimp/gimps/GimLocation.java
+++ b/src/main/java/com/gimp/gimps/GimLocation.java
@@ -24,13 +24,12 @@
  */
 package com.gimp.gimps;
 
-import java.awt.image.BufferedImage;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.coords.WorldPoint;
+
 import java.util.HashMap;
 import java.util.Map;
-import net.runelite.api.coords.WorldPoint;
-import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
 
 @Slf4j
 public class GimLocation
@@ -51,18 +50,11 @@ public class GimLocation
 	@Getter
 	final int plane;
 
-	@Getter
-	final WorldPoint worldPoint;
-
-	@Getter
-	WorldMapPoint worldMapPoint;
-
 	public GimLocation(WorldPoint worldPoint)
 	{
 		x = worldPoint.getX();
 		y = worldPoint.getY();
 		plane = worldPoint.getPlane();
-		this.worldPoint = worldPoint;
 	}
 
 	public GimLocation(int x, int y, int plane)
@@ -70,7 +62,6 @@ public class GimLocation
 		this.x = x;
 		this.y = y;
 		this.plane = plane;
-		worldPoint = new WorldPoint(x, y, plane);
 	}
 
 	/**
@@ -87,18 +78,14 @@ public class GimLocation
 		return location;
 	}
 
-	public void setWorldMapPoint(String name, BufferedImage gimpIcon)
+	public WorldPoint toWorldPoint()
 	{
-		// Set world map point
-		worldMapPoint = new WorldMapPoint(worldPoint, gimpIcon);
-		// Configure world map point
-		worldMapPoint.setTarget(worldPoint);
-		// Snaps to edge if outside of current map frame
-		worldMapPoint.setSnapToEdge(true);
-		// Jumps to location if clicked on
-		worldMapPoint.setJumpOnClick(true);
-		// Name is necessary for jumpOnClick behavior
-		worldMapPoint.setName(name);
+		return new WorldPoint(x, y, plane);
+	}
+
+	public double getDistanceTo(GimLocation other)
+	{
+		return Math.sqrt(Math.pow(other.x - x, 2) + Math.pow(other.y - y, 2));
 	}
 
 	public static boolean compare(GimLocation loc1, GimLocation loc2)

--- a/src/main/java/com/gimp/map/GimIconProvider.java
+++ b/src/main/java/com/gimp/map/GimIconProvider.java
@@ -22,8 +22,9 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.gimp;
+package com.gimp.map;
 
+import com.gimp.GimPlugin;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.util.ImageUtil;
 
@@ -34,6 +35,9 @@ import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Utility for constructing and caching GIM world map icons.
+ */
 public class GimIconProvider
 {
 	final static Font FONT = FontManager.getRunescapeBoldFont();

--- a/src/main/java/com/gimp/map/GimWorldMapPoint.java
+++ b/src/main/java/com/gimp/map/GimWorldMapPoint.java
@@ -1,0 +1,102 @@
+package com.gimp.map;
+
+import com.gimp.gimps.GimLocation;
+import com.gimp.gimps.GimPlayer;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
+
+/**
+ * Wrapper around the built-in {@link WorldMapPoint}.
+ * Creates abstraction for "moving" the world map point by altering the underlying map point location.
+ *
+ * Supports fractional locations which allows for map points to be moved more slowly.
+ * TODO: The current implementation doesn't actually need this due to the "frame toggle" approach; delete when sure.
+ */
+public class GimWorldMapPoint
+{
+	private final WorldMapPoint worldMapPoint;
+	private double x;
+	private double y;
+
+	public GimWorldMapPoint(WorldMapPoint worldMapPoint)
+	{
+		this.worldMapPoint = worldMapPoint;
+		x = this.worldMapPoint.getWorldPoint().getX();
+		y = this.worldMapPoint.getWorldPoint().getY();
+	}
+
+	public void setX(double x)
+	{
+		this.x = x;
+		refreshWorldPoint();
+	}
+
+	public void setY(double y)
+	{
+		this.y = y;
+		refreshWorldPoint();
+	}
+
+	public void move(double dx, double dy)
+	{
+		x += dx;
+		y += dy;
+		refreshWorldPoint();
+	}
+
+	public void setWorldPoint(WorldPoint worldPoint)
+	{
+		worldMapPoint.setWorldPoint(worldPoint);
+		x = worldPoint.getX();
+		y = worldPoint.getY();
+	}
+
+	public WorldPoint getWorldPoint()
+	{
+		return worldMapPoint.getWorldPoint();
+	}
+
+	public WorldMapPoint getWorldMapPoint()
+	{
+		return worldMapPoint;
+	}
+
+	private void refreshWorldPoint()
+	{
+		if ((int) x != worldMapPoint.getWorldPoint().getX()
+			|| (int) y != worldMapPoint.getWorldPoint().getY())
+		{
+			final WorldPoint newWorldPoint = new WorldPoint((int) x, (int) y, worldMapPoint.getWorldPoint().getPlane());
+			worldMapPoint.setWorldPoint(newWorldPoint);
+		}
+	}
+
+	public void moveTowardPlayer(GimPlayer gimp, boolean frameToggle)
+	{
+		final String name = gimp.getName();
+		final WorldPoint shownLocation = getWorldPoint();
+		final GimLocation targetLocation = gimp.getLocation();
+		if (shownLocation != null && targetLocation != null)
+		{
+			int dx = targetLocation.getX() - shownLocation.getX();
+			int dy = targetLocation.getY() - shownLocation.getY();
+			if (targetLocation.getPlane() != shownLocation.getPlane()
+				|| Math.abs(dx) > 30
+				|| Math.abs(dy) > 30)
+			{
+				// If the target location is too far (or in another plane), instantly change the map point
+				setWorldPoint(targetLocation.toWorldPoint());
+			}
+			else if (dx != 0 || dy != 0)
+			{
+				// Otherwise if it's moved at all, smoothly move it toward the target location.
+				// If moving fast (e.g. running), move every frame; otherwise, move every other frame.
+				if (frameToggle || gimp.getSpeed() > 2.25)
+				{
+					// Only move by a max of 1 tile in a given axis (keeps it consistent/smooth)
+					move(Math.min(1, Math.max(dx, -1)), Math.min(1, Math.max(dy, -1)));
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/com/gimp/map/GimWorldMapPointManager.java
+++ b/src/main/java/com/gimp/map/GimWorldMapPointManager.java
@@ -1,0 +1,110 @@
+package com.gimp.map;
+
+import com.gimp.gimps.GimPlayer;
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
+
+/**
+ * Wrapper around the built-in {@link WorldMapPointManager}.
+ * Primarily adds support for tracking and fetching map points by name.
+ */
+@Slf4j
+public class GimWorldMapPointManager
+{
+	@Inject
+	private WorldMapPointManager _worldMapPointManager;
+
+	private final Map<String, GimWorldMapPoint> points;
+	private final GimIconProvider iconProvider;
+
+	public GimWorldMapPointManager()
+	{
+		points = new HashMap<>();
+		iconProvider = new GimIconProvider();
+	}
+
+	public GimWorldMapPoint getPoint(String gimpName)
+	{
+		if (!points.containsKey(gimpName))
+		{
+			throw new IllegalArgumentException("WorldMapPoint does not exist for user " + gimpName);
+		}
+		return points.get(gimpName);
+	}
+
+	public boolean hasPoint(String gimpName)
+	{
+		return points.containsKey(gimpName);
+	}
+
+	/**
+	 * Add the given map point to the world map for the given player.
+	 *
+	 * @param gimpName      name of the player
+	 * @param worldMapPoint world map point to add
+	 */
+	public void addPoint(String gimpName, GimWorldMapPoint worldMapPoint)
+	{
+		if (!points.containsKey(gimpName))
+		{
+			points.put(gimpName, worldMapPoint);
+			_worldMapPointManager.add(worldMapPoint.getWorldMapPoint());
+			log.info("Add world map point for " + gimpName);
+		}
+		else
+		{
+			throw new IllegalStateException("WorldMapPoint for user " + gimpName + " already exists");
+		}
+	}
+
+	/**
+	 * For the given player, create and add a map point to the world map.
+	 *
+	 * @param gimp player for whom to create and add a map point
+	 */
+	public void addPoint(GimPlayer gimp)
+	{
+		final String name = gimp.getName();
+		final WorldPoint p = new WorldPoint(gimp.getLocation().getX(),
+			gimp.getLocation().getY(),
+			gimp.getLocation().getPlane());
+		final WorldMapPoint worldMapPoint = new WorldMapPoint(p, iconProvider.getIcon(name));
+		// Configure world map point
+		worldMapPoint.setTarget(p);
+		// Snaps to edge if outside of current map frame
+		worldMapPoint.setSnapToEdge(true);
+		// Jumps to location if clicked on
+		worldMapPoint.setJumpOnClick(true);
+		// Name is necessary for jumpOnClick behavior
+		worldMapPoint.setName(name);
+
+		addPoint(name, new GimWorldMapPoint(worldMapPoint));
+	}
+
+	public void removePoint(String gimpName)
+	{
+		if (points.containsKey(gimpName))
+		{
+			_worldMapPointManager.remove(points.get(gimpName).getWorldMapPoint());
+			points.remove(gimpName);
+			log.info("Remove map point for " + gimpName);
+		}
+		else
+		{
+			throw new IllegalStateException("Cannot remove nonexistent WorldMapPoint for user " + gimpName);
+		}
+	}
+
+	public void clear()
+	{
+		for (String gimpName : points.keySet())
+		{
+			removePoint(gimpName);
+		}
+	}
+}


### PR DESCRIPTION
Refactors map point logic to be completely separate from the classes
containing group/player/location state. The map points are now moved
and added/removed on a ticker loop (currently 300ms). Created new
wrapper classes for world map points and the world map point manager.